### PR TITLE
Check for configuration file in /etc/ for Posix

### DIFF
--- a/config.d
+++ b/config.d
@@ -53,6 +53,11 @@ shared static this()
 			opts.configFile = buildPath(__FILE__.dirName, CONFIG_FILE);
 		if (!opts.configFile.exists)
 			opts.configFile = buildPath(environment.get("HOME", environment.get("USERPROFILE")), ".digger", CONFIG_FILE);
+		version (Posix)
+		{
+			if (!opts.configFile.exists)
+				opts.configFile = buildPath("/etc/", CONFIG_FILE);
+		}
 	}
 
 	if (opts.configFile.exists)

--- a/digger.ini.sample
+++ b/digger.ini.sample
@@ -2,7 +2,9 @@
 # changes below.
 # Digger looks for digger.ini in these locations, in order:
 # current directory, EXE directory, source directory, and
-# ~/.digger/digger.ini.
+# ~/.digger/digger.ini
+# On Posix systems it also looks for /etc/digger.ini as
+# option of last resort
 
 # Working directory.
 # This directory will contain all of Digger's working files:


### PR DESCRIPTION
Necessary to do standardized system-wide installation of digger that "just works".