### PR TITLE
Correct "Get Digger" section about dub

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ On Windows, Digger will download and unpack everything it needs (Git, DMC, DMD, 
 
 The easiest way to obtain and run Digger is through Dub. As Dub is included with DMD, simply run:
 
+    $ dub fetch digger
     $ dub run digger -- ...args...
 
 You can find binaries on the [GitHub releases](https://github.com/CyberShadow/Digger/releases) page.


### PR DESCRIPTION
Dub packages must first be fetched before you can run them, at least
until https://github.com/dlang/dub/pull/1082 is accepted.