### PR TITLE
Update url path of ae submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ae"]
 	path = ae
-	url = git://github.com/CyberShadow/ae.git
+	url = https://github.com/CyberShadow/ae
 [submodule "win32"]
 	path = win32
 	url = https://github.com/CS-svnmirror/dsource-bindings-win32


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported on GitHub.

See also https://github.blog/2021-09-01-improving-git-protocol-security-github/